### PR TITLE
refactor(deps): express security overrides as floors, drop dead pins

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,8 @@
     "@astrojs/sitemap": "3.7.2",
     "@vercel/analytics": "1.6.1",
     "astro": "6.4.6",
-    "fast-uri": "3.1.4",
-    "sharp": "0.35.0",
-    "typescript": "6.0.3",
-    "yaml": "2.9.0"
+    "sharp": "^0.35.0",
+    "typescript": "6.0.3"
   },
   "devDependencies": {
     "@astrojs/vercel": "10.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,14 +6,14 @@ settings:
 
 overrides:
   vite: 7.3.5
-  brace-expansion: 5.0.7
-  esbuild: 0.28.1
-  fast-uri: 3.1.4
-  js-yaml: 4.3.0
-  postcss: 8.5.24
-  sharp: 0.35.0
-  svgo: 4.0.2
-  tar: 7.5.18
+  brace-expansion: ^5.0.7
+  esbuild: ^0.28.1
+  fast-uri: ^3.1.4
+  js-yaml: ^4.3.0
+  postcss: ^8.5.24
+  sharp: ^0.35.0
+  svgo: ^4.0.2
+  tar: ^7.5.18
 
 patchedDependencies:
   '@astrojs/vercel@10.0.8': 4facaf5127af1f3d757164f97e07bdeed0b105cf0fd05286c43719cc64ebfec9
@@ -36,18 +36,12 @@ importers:
       astro:
         specifier: 6.4.6
         version: 6.4.6(patch_hash=8ee77e67af9b7bb308286501d56a14e76bf4313b42f42bc7090b6bd3b4cbafa2)(@types/node@24.13.2)(@vercel/functions@3.7.1)(jiti@2.7.0)(lightningcss@1.32.0)(rollup@4.62.0)(yaml@2.9.0)
-      fast-uri:
-        specifier: 3.1.4
-        version: 3.1.4
       sharp:
-        specifier: 0.35.0
+        specifier: ^0.35.0
         version: 0.35.0
       typescript:
         specifier: 6.0.3
         version: 6.0.3
-      yaml:
-        specifier: 2.9.0
-        version: 2.9.0
     devDependencies:
       '@astrojs/vercel':
         specifier: 10.0.8
@@ -56,7 +50,7 @@ importers:
         specifier: 4.3.3
         version: 4.3.3(vite@7.3.5(patch_hash=ac289d19046e9356c44b762eb05e8359bf9d9bdb9f604e7fc88b5f876dd90802)(@types/node@24.13.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       esbuild:
-        specifier: 0.28.1
+        specifier: ^0.28.1
         version: 0.28.1
       tailwindcss:
         specifier: 4.3.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,22 +2,30 @@ allowBuilds:
   esbuild: true
   sharp: true
 # Security pins raise a transitive dependency above the version natural
-# resolution would pick. Remove an entry once the upstream range already
-# resolves to a patched version on its own.
+# resolution would pick. They are floors, not exact versions: an override
+# replaces the consumer's range outright, so an exact pin would freeze the
+# dependency and silently win over any later bump. The caret keeps the floor
+# while staying inside the range the consumers were written against -- note
+# that for 0.x releases it still caps at the next minor, which is where those
+# packages put their breaking changes.
+#
+# Remove an entry once the upstream range already resolves above the floor on
+# its own.
 overrides:
-  # Not a security pin: `autoInstallPeers` resolves the @tailwindcss/vite peer
-  # range (^5.2.0 || ^6 || ^7 || ^8) to the highest match, pulling a second,
-  # Rolldown-based Vite 8 that the plugin cannot drive. Keep it on the Vite
-  # that Astro itself depends on. Bump together with patches/vite@7.3.5.patch.
+  # Not a security pin, and exact on purpose: `autoInstallPeers` resolves the
+  # @tailwindcss/vite peer range (^5.2.0 || ^6 || ^7 || ^8) to the highest
+  # match, pulling a second, Rolldown-based Vite 8 that the plugin cannot
+  # drive. Keep it on the Vite that Astro itself depends on, and bump it
+  # together with patches/vite@7.3.5.patch, which is keyed to this version.
   vite: 7.3.5
-  brace-expansion: 5.0.7 # GHSA-3jxr-9vmj-r5cp
-  esbuild: 0.28.1 # GHSA-g7r4-m6w7-qqqr
-  fast-uri: 3.1.4 # GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6
-  js-yaml: 4.3.0 # GHSA-52cp-r559-cp3m
-  postcss: 8.5.24 # GHSA-r28c-9q8g-f849, GHSA-6g55-p6wh-862q, GHSA-qx2v-qp2m-jg93
-  sharp: 0.35.0 # GHSA-f88m-g3jw-g9cj
-  svgo: 4.0.2 # GHSA-2p49-hgcm-8545
-  tar: 7.5.18 # GHSA-w8wr-v893-vjvp
+  brace-expansion: ^5.0.7 # GHSA-3jxr-9vmj-r5cp
+  esbuild: ^0.28.1 # GHSA-g7r4-m6w7-qqqr
+  fast-uri: ^3.1.4 # GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6
+  js-yaml: ^4.3.0 # GHSA-52cp-r559-cp3m
+  postcss: ^8.5.24 # GHSA-r28c-9q8g-f849, GHSA-6g55-p6wh-862q, GHSA-qx2v-qp2m-jg93
+  sharp: ^0.35.0 # GHSA-f88m-g3jw-g9cj
+  svgo: ^4.0.2 # GHSA-2p49-hgcm-8545
+  tar: ^7.5.18 # GHSA-w8wr-v893-vjvp
 patchedDependencies:
   '@astrojs/vercel@10.0.8': patches/@astrojs__vercel@10.0.8.patch
   astro@6.4.6: patches/astro@6.4.6.patch


### PR DESCRIPTION
> **Stacked on #33.** Base is `fix/postcss-path-traversal`; GitHub retargets this to `master` automatically once #33 merges. Review #33 first.

## The problem

A pnpm override replaces the consumer's range outright. The exact pins introduced with the overrides block therefore froze each dependency and silently win over any later bump — the opposite of what a security floor should do.

Dependabot surfaced it within minutes of the ecosystem fix landing:

| PR | Proposes | Override says | Result if merged |
|----|----------|---------------|------------------|
| #29 | `sharp` 0.35.3 | `sharp: 0.35.0` | package.json states 0.35.3, tree installs 0.35.0 |
| #32 | `fast-uri` 4.1.1 | `fast-uri: 3.1.4` | package.json states 4.1.1, tree installs 3.1.4 |

A manifest that claims something the lockfile does not do. This would repeat for all eight pinned packages, forever.

## The fix

Pins become caret ranges — floors that keep the security guarantee while staying inside the range the consumers were written against. For the `0.x` entries the caret still caps at the next minor, which is where those projects put their breaking changes.

`vite` stays exact and the comment now says why: it is not a security pin, and `patches/vite@7.3.5.patch` is keyed to that exact version.

## Dead direct dependencies

`fast-uri` and `yaml` are removed. Neither is imported anywhere, and a direct dependency does not force transitive versions in pnpm — they only generated Dependabot churn against packages the overrides already govern. Their real consumers were verified to resolve independently:

- `ajv@8.20.0` -> `fast-uri` 3.1.4 (`ajv@6.15.0` is also in the tree and uses `uri-js`, not fast-uri)
- `vite` -> `yaml` 2.9.0
- `yaml-language-server` -> its own exact `yaml` 2.7.1

## `sharp` is not one of them

It reads like the identical redundant pin — astro declares `optionalDependencies.sharp: ^0.34.0`, nothing in `src/` imports it. Removing it breaks the build:

```
MissingSharp: Could not find Sharp. Please install Sharp (`sharp`)
manually into your project or migrate to another image service.
```

The failure is invisible on an incremental build: astro serves the images from `node_modules/.astro/assets` and reports success. It only appears once that cache is cleared. `sharp` is kept, loosened to `^0.35.0` to match the floor.

## Changes

| File | Change |
|------|--------|
| `pnpm-workspace.yaml` | Seven pins become caret floors; `vite` documented as a deliberate exact pin |
| `package.json` | Drops `fast-uri` and `yaml`; `sharp` loosened to `^0.35.0` |
| `pnpm-lock.yaml` | Regenerated |

## Test plan

- [x] `pnpm build` green (astro check: 0 errors) after removing **both** `dist` and `node_modules/.astro/assets`, so nothing is served from cache.
- [x] All 10 images optimised from scratch through sharp.
- [x] Every removed dependency confirmed to still resolve for its actual consumer.
- [x] Floors verified in the regenerated lockfile.

## Follow-up

#28 is superseded by #33. #29 and #32 become mergeable-without-lying once this lands, though #32 (`fast-uri` 4.x major) still needs judgement — `ajv` requires `^3.0.1`, so the major cannot apply to the tree regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)